### PR TITLE
Fix installation commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ $ npm install ccurl.interface.js
 
 After that, you will have to compile cCurl locally on your machine. Follow the instructions on the [official repo here](#https://github.com/iotaledger/ccurl).
 ```
-$ git clone https://github.com/iotaledger/ccurl.git
-$ mkdir build && cd build && cmake .. && cd .. && make -C build
+$ git clone --recursive https://github.com/iotaledger/ccurl.git
+$ cd ccurl && mkdir build && cd build && cmake .. && cd .. && make -C build
 ```
 
 Then copy the `libccurl` library from the `build/lib` folder to the main directory.


### PR DESCRIPTION
This fixes the commands for cloning and installing `ccurl`. The repo must be cloned recursively to obtain the dependencies and then you must `cd` into the repo directory before running the next commands.