### PR TITLE
When using an emitter, loopTrytes should be started manually

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,44 @@ Then copy the `libccurl` library from the `build/lib` folder to the main directo
 
 Using this library is fairly simple. You can optionally provide the full path where you have your compiled libccurl. 
 
-```
-var ccurl = import('ccurl.interface.js');
+### API
 
-ccurl(trunkTransaction, branchTransaction, trytes, minWeightMagnitude, [, path], callback)
+```
+ccurl(
+    trunkTransaction: string,
+    branchTransaction: string,
+    trytes: string[],
+    minWeightMagnitude: number,
+    path?: string,
+    callback?: (error: Error, result: string[]) => void
+): EventEmitter | void
 ```
 
-See `example.js`.
+When no callback is passed, the method returns an `EventEmitter` which allows you to track job progress. You must call `start` to begin the job.
+
+#### Events:
+
+- `'progress'`: Callback `result` is a number between 0 and 1 as a fraction of `trytes.length`
+- `'done'`: Callback `result` is the array of tryte strings
+
+#### Methods:
+
+- `start: () => void`: Begin the job.
+
+#### Example:
+
+```
+const ccurl = require('ccurl.interface.js')
+
+const job = ccurl(trunkTransaction, branchTransaction, trytes, minWeightMagnitude, [, path])
+
+job.on('progress', (err, progress) => {
+    console.log(progress) // A number between 0 and 1 as a percentage of `trytes.length`
+})
+
+job.on('done', callback)
+
+job.start()
+```
+
+See `example.js` or `test/test.js`.

--- a/index.js
+++ b/index.js
@@ -188,9 +188,11 @@ module.exports = function(trunkTransaction, branchTransaction, minWeightMagnitud
         }
     }
 
-    loopTrytes();
-
     if (emitter) {
+        emitter.start = loopTrytes
+        
         return emitter;
     }
+
+    loopTrytes();
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ccurl.interface.js",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "ccurl interface for nodejs",
   "main": "index.js",
   "engines" : {


### PR DESCRIPTION
A race condition occured where for low values of `minWeightMagnitude`, the ccurl process would finish before the emitter was attached from the calling code of this library. Now you must manually call `start` on the emitter after the handlers are attached.